### PR TITLE
Use optional build-args (closes #9)

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,7 +1,7 @@
-FROM okteto/bin:1.0.4 as cli
+FROM okteto/bin:1.1.5-cloud as cli
 
 # Container image that runs your code
-FROM alpine:3.10
+FROM alpine:3.11
 
 COPY --from=cli /usr/local/bin/okteto /usr/local/bin/okteto
 

--- a/build/action.yml
+++ b/build/action.yml
@@ -1,6 +1,6 @@
 name: 'Build'
 description: 'Build an image from a Dockerfile using Okteto Cloud'
-inputs: 
+inputs:
   tag:
     description: 'Name and tag in the "name:tag" format'
     required: true
@@ -15,6 +15,9 @@ inputs:
     description: 'The path'
     required: false
     default: '.'
+  buildargs:
+    description: 'Use buildargs when you want to pass a list of environment variables as build-args'
+    required: false
 runs:
   using: 'docker'
   image: 'Dockerfile'
@@ -23,3 +26,4 @@ runs:
     - ${{ inputs.tag }}
     - ${{ inputs.file }}
     - ${{ inputs.path }}
+    - ${{ inputs.buildargs }}

--- a/build/entrypoint.sh
+++ b/build/entrypoint.sh
@@ -5,8 +5,24 @@ token=$1
 tag=$2
 file=$3
 path=$4
+args=$5
+
+BUILDPARAMS=""
 
 export OKTETO_TOKEN=$token
-echo okteto build -t "$tag" -f "$file" "$path"
-okteto version
-okteto build -t "$tag" -f "$file" "$path"
+
+if [ ! -d ${HOME}/.okteto ]; then
+  mkdir ${HOME}/.okteto
+fi
+
+wget -O ${HOME}/.okteto/.ca.crt https://storage.googleapis.com/get.okteto.com/okteto-cloud-ca-crt
+
+if [ ! -z "${INPUT_BUILDARGS}" ]; then
+  for ARG in $(echo "${INPUT_BUILDARGS}" | tr ',' '\n'); do
+    BUILDPARAMS="${BUILDPARAMS} --build-arg ${ARG}=\'\$${ARG}\'"
+  done
+fi
+
+params=$(eval echo -t "$tag" -f "$file" "$BUILDPARAMS" "$path")
+echo $params
+okteto build $params

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,7 +1,7 @@
-FROM okteto/bin:1.0.4 as cli
+FROM okteto/bin:1.1.5-cloud as cli
 
 # Container image that runs your code
-FROM alpine:3.10
+FROM alpine:3.11
 
 COPY --from=cli /usr/local/bin/okteto /usr/local/bin/okteto
 

--- a/namespace/Dockerfile
+++ b/namespace/Dockerfile
@@ -1,7 +1,7 @@
-FROM okteto/bin:1.0.4 as cli
+FROM okteto/bin:1.1.5-cloud as cli
 
 # Container image that runs your code
-FROM alpine:3.10
+FROM alpine:3.11
 
 COPY --from=cli /usr/local/bin/okteto /usr/local/bin/okteto
 


### PR DESCRIPTION
Signed-off-by: Andreas Amstutz <andreasamstutz@gmail.com>

Ths PR adds optional build-args to okteto build

Test config for the action step:

```
    - name: Build
      uses: okteto/actions/build@v1
      env:
        BUILD_DATE: ${{ steps.date.outputs.date }}
        PACKAGE_NAME: sales-api
        VCS_REF: ${{ github.sha }}      
      with:
        file: dockerfile.sales-api
        token: ${{ secrets.OKTETO_TOKEN }}
        tag: registry.cloud.okteto.net/${{ secrets.OKTETO_NS }}/sales-api-amd64:${{ github.sha }}
        buildargs: PACKAGE_NAME,VCS_REF,BUILD_DATE
```