### PR TITLE
Add actions for push, create namespace and delete namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,19 @@ Use these actions to deploy your Kubernetes applications directly into [Okteto C
 
 # Actions available
 
-## Build
-Build an image in Okteto Cloud and push it to the registry.
+## Login
+Login to Okteto Cloud. This should be run before any other action.
 
 ### Inputs
 
 #### `token`
 
 **Required** Your okteto API token.
+
+## Build
+Build an image in Okteto Cloud and push it to the registry.
+
+### Inputs
 
 #### `tag`
 
@@ -59,23 +64,24 @@ Name of the resource to wait on. Must follow the `"resource/name"` format.
 Set this to `registry.cloud.okteto.net` for an image built and tagged with `registry.cloud.okteto.net/<namespace>/<image>:<tag>`.
 
 ```yaml
+    - name: Login
+      users: okteto/actions/login@master
+      with:
+        token: ${{ secrets.OKTETO_TOKEN }}
+        
     - name: Build & Publish to Okteto registry
       uses: okteto/actions/build@master
       with:
-        token: ${{ secrets.OKTETO_TOKEN }}
         tag: registry.cloud.okteto.net/okteto-ns/image-name:tag
 
     - name: Get Kubeconfig
       uses: okteto/actions/namespace@master
       id: namespace
       with:
-        token: ${{ secrets.OKTETO_TOKEN }}
         namespace: okteto-ns
 
     - name: Deploy and Wait
       uses: okteto/actions/deploy@master
-      env:
-        KUBECONFIG: ${{ steps.namespace.outputs.kubeconfig }}  
       with:
         namespace: okteto-ns
         manifest: k8s.yml
@@ -92,16 +98,6 @@ Retrieve the credentials of the namespace from Okteto Cloud.
 #### `namespace`
 
 **Required** The name of the Okteto Cloud namespace. It must already exist.
-
-#### `token`
-
-**Required** Your okteto API token.
-
-### Outputs
-
-#### `kubeconfig`
-
-The path to the generated `kubeconfig` file.
 
 # Example 
 
@@ -122,18 +118,20 @@ jobs:
     steps:
     - uses: actions/checkout@master
     
-    - uses: okteto/actions/namespace@master
+    - uses: okteto/actions/login@master
       with:
         token: ${{ secrets.OKTETO_TOKEN }}
+
+    - uses: okteto/actions/namespace@master
+      with:
         namespace: actions-rberrelleza
 
     - uses: okteto/actions/push@master
-      env:
-        KUBECONFIG: ${{ steps.namespace.outputs.kubeconfig }}  
       with:
-        token: ${{ secrets.OKTETO_TOKEN }}
+        namespace: actions-rberrelleza
+        name: hello-world
         deploy: "true"
-        name: "hello-world"
+        
 ```
 
 [Review this sample repo](https://github.com/rberrelleza/actions-test) to see a live example of the different available actions and the checks.

--- a/README.md
+++ b/README.md
@@ -103,7 +103,9 @@ Retrieve the credentials of the namespace from Okteto Cloud.
 
 The path to the generated `kubeconfig` file.
 
-# Example usage: Build a container, push it, and deploy it to Okteto Cloud
+# Example 
+
+This example builds a container with your changes and deploys it to Okteto Cloud. It assumes the deployment is called `hello-world`, and uses the `actions-rberrelleza` namespace.
 
 ## Prerequisites
 
@@ -120,26 +122,18 @@ jobs:
     steps:
     - uses: actions/checkout@master
     
-
-    - uses: okteto/actions/build@master
-      with:
-        token: ${{ secrets.OKTETO_TOKEN }}
-        tag: registry.cloud.okteto.net/cindy/actions-test:${{ github.sha }}
-
     - uses: okteto/actions/namespace@master
-      id: namespace
       with:
         token: ${{ secrets.OKTETO_TOKEN }}
         namespace: actions-rberrelleza
-    
-    - uses: okteto/actions/deploy@master
+
+    - uses: okteto/actions/push@master
       env:
         KUBECONFIG: ${{ steps.namespace.outputs.kubeconfig }}  
       with:
-        namespace: actions-rberrelleza
-        manifest: k8s.yml
-        tag: registry.cloud.okteto.net/cindy/actions-test:${{ github.sha }}
-        waitOn: deployment/hello-world  
+        token: ${{ secrets.OKTETO_TOKEN }}
+        deploy: "true"
+        name: "hello-world"
 ```
 
 [Review this sample repo](https://github.com/rberrelleza/actions-test) to see a live example of the different available actions and the checks.

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM okteto/bin:1.1.6-cloud as cli
+FROM okteto/bin:1.1.8-cloud
 
 # Container image that runs your code
 FROM alpine:3.11

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM okteto/bin:1.1.8-dev
+FROM okteto/bin:1.1.8-dev as cli
 
 # Container image that runs your code
 FROM alpine:3.11

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM okteto/bin:1.1.8-cloud
+FROM okteto/bin:1.1.8-dev
 
 # Container image that runs your code
 FROM alpine:3.11

--- a/build/action.yml
+++ b/build/action.yml
@@ -4,9 +4,6 @@ inputs:
   tag:
     description: 'Name and tag in the "name:tag" format'
     required: true
-  token: 
-    description: 'Your okteto API token'
-    required: true
   file:
     description: 'Name of the Dockerfile (Default is "Dockerfile")'
     required: false
@@ -22,7 +19,6 @@ runs:
   using: 'docker'
   image: 'Dockerfile'
   args:
-    - ${{ inputs.token }}
     - ${{ inputs.tag }}
     - ${{ inputs.file }}
     - ${{ inputs.path }}

--- a/build/entrypoint.sh
+++ b/build/entrypoint.sh
@@ -1,15 +1,12 @@
 #!/bin/sh
 set -e
 
-token=$1
-tag=$2
-file=$3
-path=$4
-args=$5
+tag=$1
+file=$2
+path=$3
+args=$4
 
 BUILDPARAMS=""
-
-okteto login --token=$token
 
 if [ ! -z "${INPUT_BUILDARGS}" ]; then
   for ARG in $(echo "${INPUT_BUILDARGS}" | tr ',' '\n'); do

--- a/create-namespace/Dockerfile
+++ b/create-namespace/Dockerfile
@@ -1,0 +1,12 @@
+FROM okteto/bin:1.1.8-cloud
+
+# Container image that runs your code
+FROM alpine:3.11
+
+COPY --from=cli /usr/local/bin/okteto /usr/local/bin/okteto
+
+# Copies your code file from your action repository to the filesystem path `/` of the container
+COPY entrypoint.sh /entrypoint.sh
+
+# Code file to execute when the docker container starts up (`entrypoint.sh`)
+ENTRYPOINT ["/entrypoint.sh"]

--- a/create-namespace/Dockerfile
+++ b/create-namespace/Dockerfile
@@ -1,4 +1,4 @@
-FROM okteto/bin:1.1.8-dev
+FROM okteto/bin:1.1.8-dev as cli
 
 # Container image that runs your code
 FROM alpine:3.11

--- a/create-namespace/Dockerfile
+++ b/create-namespace/Dockerfile
@@ -1,4 +1,4 @@
-FROM okteto/bin:1.1.8-cloud
+FROM okteto/bin:1.1.8-dev
 
 # Container image that runs your code
 FROM alpine:3.11

--- a/create-namespace/action.yml
+++ b/create-namespace/action.yml
@@ -1,0 +1,15 @@
+name: "Create Namespace"
+description: "Create a namespace in Okteto Cloud"
+inputs:
+  token: 
+    description: "Your okteto API token"
+    required: true
+  namespace: 
+    description: "The namespace name"
+    required: true
+runs:
+  using: "docker"
+  image: "Dockerfile"
+  args:
+    - ${{ inputs.token }}
+    - ${{ inputs.namespace }}

--- a/create-namespace/action.yml
+++ b/create-namespace/action.yml
@@ -1,9 +1,6 @@
 name: "Create Namespace"
 description: "Create a namespace in Okteto Cloud"
 inputs:
-  token: 
-    description: "Your okteto API token"
-    required: true
   namespace: 
     description: "The namespace name"
     required: true
@@ -11,5 +8,4 @@ runs:
   using: "docker"
   image: "Dockerfile"
   args:
-    - ${{ inputs.token }}
     - ${{ inputs.namespace }}

--- a/create-namespace/entrypoint.sh
+++ b/create-namespace/entrypoint.sh
@@ -1,11 +1,7 @@
 #!/bin/sh
 set -e
 
-token=$1
-namespace=$2
+namespace=$1
 
-okteto login --token=$token
-echo okteto create namespace $namespace
+echo  running: okteto create namespace $namespace
 okteto create namespace $namespace
-k="/github/home/.kube/config"
-echo "::set-output name=kubeconfig::$k"

--- a/create-namespace/entrypoint.sh
+++ b/create-namespace/entrypoint.sh
@@ -7,3 +7,5 @@ namespace=$2
 okteto login --token=$token
 echo okteto create namespace $namespace
 okteto create namespace $namespace
+k="/github/home/.kube/config"
+echo "::set-output name=kubeconfig::$k"

--- a/create-namespace/entrypoint.sh
+++ b/create-namespace/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -e
+
+token=$1
+namespace=$2
+
+okteto login --token=$token
+echo okteto create namespace $namespace
+okteto create namespace $namespace

--- a/delete-namespace/Dockerfile
+++ b/delete-namespace/Dockerfile
@@ -1,0 +1,12 @@
+FROM okteto/bin:1.1.8-cloud
+
+# Container image that runs your code
+FROM alpine:3.11
+
+COPY --from=cli /usr/local/bin/okteto /usr/local/bin/okteto
+
+# Copies your code file from your action repository to the filesystem path `/` of the container
+COPY entrypoint.sh /entrypoint.sh
+
+# Code file to execute when the docker container starts up (`entrypoint.sh`)
+ENTRYPOINT ["/entrypoint.sh"]

--- a/delete-namespace/Dockerfile
+++ b/delete-namespace/Dockerfile
@@ -1,4 +1,4 @@
-FROM okteto/bin:1.1.8-dev
+FROM okteto/bin:1.1.8-dev as cli
 
 # Container image that runs your code
 FROM alpine:3.11

--- a/delete-namespace/Dockerfile
+++ b/delete-namespace/Dockerfile
@@ -1,4 +1,4 @@
-FROM okteto/bin:1.1.8-cloud
+FROM okteto/bin:1.1.8-dev
 
 # Container image that runs your code
 FROM alpine:3.11

--- a/delete-namespace/action.yml
+++ b/delete-namespace/action.yml
@@ -1,9 +1,6 @@
 name: "Delete Namespace"
 description: "Delete an Okteto Cloud namespace and all its resources"
 inputs:
-  token: 
-    description: "Your okteto API token"
-    required: true
   namespace: 
     description: "The namespace name"
     required: true
@@ -11,5 +8,4 @@ runs:
   using: "docker"
   image: "Dockerfile"
   args:
-    - ${{ inputs.token }}
     - ${{ inputs.namespace }}

--- a/delete-namespace/action.yml
+++ b/delete-namespace/action.yml
@@ -1,0 +1,15 @@
+name: "Delete Namespace"
+description: "Delete an Okteto Cloud namespace and all its resources"
+inputs:
+  token: 
+    description: "Your okteto API token"
+    required: true
+  namespace: 
+    description: "The namespace name"
+    required: true
+runs:
+  using: "docker"
+  image: "Dockerfile"
+  args:
+    - ${{ inputs.token }}
+    - ${{ inputs.namespace }}

--- a/delete-namespace/entrypoint.sh
+++ b/delete-namespace/entrypoint.sh
@@ -1,9 +1,6 @@
 #!/bin/sh
 set -e
 
-token=$1
-namespace=$2
-
-okteto login --token=$token
-echo okteto delete namespace $namespace
+namespace=$1
+echo running: okteto delete namespace $namespace
 okteto delete namespace $namespace

--- a/delete-namespace/entrypoint.sh
+++ b/delete-namespace/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -e
+
+token=$1
+namespace=$2
+
+okteto login --token=$token
+echo okteto delete namespace $namespace
+okteto delete namespace $namespace

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM okteto/bin:1.1.6-cloud as cli
+FROM okteto/bin:1.1.8-cloud
 
 # Container image that runs your code
 FROM alpine:3.11

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM okteto/bin:1.1.8-dev
+FROM okteto/bin:1.1.8-dev as cli
 
 # Container image that runs your code
 FROM alpine:3.11

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM okteto/bin:1.1.8-cloud
+FROM okteto/bin:1.1.8-dev
 
 # Container image that runs your code
 FROM alpine:3.11

--- a/login/Dockerfile
+++ b/login/Dockerfile
@@ -1,0 +1,12 @@
+FROM okteto/bin:1.1.8-cloud
+
+# Container image that runs your code
+FROM alpine:3.11
+
+COPY --from=cli /usr/local/bin/okteto /usr/local/bin/okteto
+
+# Copies your code file from your action repository to the filesystem path `/` of the container
+COPY entrypoint.sh /entrypoint.sh
+
+# Code file to execute when the docker container starts up (`entrypoint.sh`)
+ENTRYPOINT ["/entrypoint.sh"]

--- a/login/Dockerfile
+++ b/login/Dockerfile
@@ -1,4 +1,4 @@
-FROM okteto/bin:1.1.8-dev
+FROM okteto/bin:1.1.8-dev as cli
 
 # Container image that runs your code
 FROM alpine:3.11

--- a/login/Dockerfile
+++ b/login/Dockerfile
@@ -1,4 +1,4 @@
-FROM okteto/bin:1.1.8-cloud
+FROM okteto/bin:1.1.8-dev
 
 # Container image that runs your code
 FROM alpine:3.11

--- a/login/action.yml
+++ b/login/action.yml
@@ -4,8 +4,12 @@ inputs:
   token: 
     description: "Your okteto API token"
     required: true
+  url: 
+    description: "Okteto Enterprise URL. Use this to run your actions in your Okteto Enterprise instance (https://okteto.com/enterprise)."
+    required: false
 runs:
   using: "docker"
   image: "Dockerfile"
   args:
     - ${{ inputs.token }}
+    - ${{ inputs.url }}

--- a/login/action.yml
+++ b/login/action.yml
@@ -1,0 +1,11 @@
+name: "Login"
+description: "Login into to an Okteto Cloud account and setup the required context"
+inputs:
+  token: 
+    description: "Your okteto API token"
+    required: true
+runs:
+  using: "docker"
+  image: "Dockerfile"
+  args:
+    - ${{ inputs.token }}

--- a/login/entrypoint.sh
+++ b/login/entrypoint.sh
@@ -2,9 +2,11 @@
 set -e
 
 token=$1
+url=$2
 if [ -z $token ]; then
   echo "Okteto API token is required"
   exit 1
 fi
 
-okteto login --token=$token
+echo running: okteto login --token=$token $url
+okteto login --token=$token $url

--- a/login/entrypoint.sh
+++ b/login/entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -e
+
+token=$1
+if [ -z $token ]; then
+  echo "Okteto API token is required"
+  exit 1
+fi
+
+okteto login --token=$token

--- a/namespace/Dockerfile
+++ b/namespace/Dockerfile
@@ -1,4 +1,4 @@
-FROM okteto/bin:1.1.6-cloud as cli
+FROM okteto/bin:1.1.8-cloud
 
 # Container image that runs your code
 FROM alpine:3.11

--- a/namespace/Dockerfile
+++ b/namespace/Dockerfile
@@ -1,4 +1,4 @@
-FROM okteto/bin:1.1.8-dev
+FROM okteto/bin:1.1.8-dev as cli
 
 # Container image that runs your code
 FROM alpine:3.11

--- a/namespace/Dockerfile
+++ b/namespace/Dockerfile
@@ -1,4 +1,4 @@
-FROM okteto/bin:1.1.8-cloud
+FROM okteto/bin:1.1.8-dev
 
 # Container image that runs your code
 FROM alpine:3.11

--- a/namespace/action.yml
+++ b/namespace/action.yml
@@ -5,15 +5,8 @@ inputs:
     description: 'The target Kubernetes namespace.'
     required: true
     default: ''
-  token: 
-    description: 'Your okteto API token'
-    required: true
-outputs:
-  kubeconfig: 
-    description: 'The path to the kubeconfig'
 runs:
   using: 'docker'
   image: 'Dockerfile'
   args:
-    - ${{ inputs.token }}
     - ${{ inputs.namespace }}

--- a/namespace/entrypoint.sh
+++ b/namespace/entrypoint.sh
@@ -1,10 +1,6 @@
 #!/bin/sh
 set -e
-token=$1
 namespace=$2
 
-okteto login --token $token
 okteto version
 okteto namespace "$namespace"
-k="/github/home/.kube/config"
-echo "::set-output name=kubeconfig::$k"

--- a/push/Dockerfile
+++ b/push/Dockerfile
@@ -6,6 +6,7 @@ FROM alpine:3.11
 
 COPY --from=cli /usr/local/bin/okteto /usr/local/bin/okteto
 COPY --from=yq /usr/bin/yq /usr/bin/yq
+COPY --from=cli /usr/local/bin/kubectl /usr/local/bin/kubectl
 
 # Copies your code file from your action repository to the filesystem path `/` of the container
 COPY entrypoint.sh /entrypoint.sh

--- a/push/Dockerfile
+++ b/push/Dockerfile
@@ -1,9 +1,11 @@
 FROM okteto/bin:1.1.8-dev as cli
+FROM mikefarah/yq as yq
 
 # Container image that runs your code
 FROM alpine:3.11
 
 COPY --from=cli /usr/local/bin/okteto /usr/local/bin/okteto
+COPY --from=yq /usr/bin/yq /usr/bin/yq
 
 # Copies your code file from your action repository to the filesystem path `/` of the container
 COPY entrypoint.sh /entrypoint.sh

--- a/push/Dockerfile
+++ b/push/Dockerfile
@@ -1,0 +1,12 @@
+FROM okteto/bin:1.1.8-cloud
+
+# Container image that runs your code
+FROM alpine:3.11
+
+COPY --from=cli /usr/local/bin/okteto /usr/local/bin/okteto
+
+# Copies your code file from your action repository to the filesystem path `/` of the container
+COPY entrypoint.sh /entrypoint.sh
+
+# Code file to execute when the docker container starts up (`entrypoint.sh`)
+ENTRYPOINT ["/entrypoint.sh"]

--- a/push/Dockerfile
+++ b/push/Dockerfile
@@ -1,4 +1,4 @@
-FROM okteto/bin:1.1.8-dev
+FROM okteto/bin:1.1.8-dev as cli
 
 # Container image that runs your code
 FROM alpine:3.11

--- a/push/Dockerfile
+++ b/push/Dockerfile
@@ -1,4 +1,4 @@
-FROM okteto/bin:1.1.8-cloud
+FROM okteto/bin:1.1.8-dev
 
 # Container image that runs your code
 FROM alpine:3.11

--- a/push/action.yml
+++ b/push/action.yml
@@ -1,20 +1,22 @@
 name: "Push"
 description: "Build, push and deploy your changes to Okteto Cloud"
 inputs:
-  token: 
-    description: "Your okteto API token"
-    required: true
+  namespace: 
+    description: 'The target Kubernetes namespace.'
+    required: false
+  name: 
+    description: "The name of the deployment. If missing, it will use the one in your okteto.yml file"
+    required: false
   deploy: 
     description: "Create the deployment if it doesn't exist in the namespace"
     required: false
     default: 'false'
-  name: 
-    description: "The name of the deployment. If missing, it will use the one in your okteto.yml file"
-    required: false
+  
 runs:
   using: "docker"
   image: "Dockerfile"
   args:
-    - ${{ inputs.token }}
-    - ${{ inputs.deploy }}
+    - ${{ inputs.namespace }}
     - ${{ inputs.name }}
+    - ${{ inputs.deploy }}
+    

--- a/push/action.yml
+++ b/push/action.yml
@@ -1,0 +1,20 @@
+name: "Push"
+description: "Build, push and deploy your changes to Okteto Cloud"
+inputs:
+  token: 
+    description: "Your okteto API token"
+    required: true
+  deploy: 
+    description: "Create the deployment if it doesn't exist in the namespace"
+    required: false
+    default: 'false'
+  name: 
+    description: "The name of the deployment. If missing, it will use the one in your okteto.yml file"
+    required: false
+runs:
+  using: "docker"
+  image: "Dockerfile"
+  args:
+    - ${{ inputs.token }}
+    - ${{ inputs.deploy }}
+    - ${{ inputs.name }}

--- a/push/entrypoint.sh
+++ b/push/entrypoint.sh
@@ -16,10 +16,10 @@ params="${params} --name $name"
 fi
 
 if [ "$deploy" == "true" ]; then
-params="--deploy"
+params="${params} --deploy"
 fi
 
-echo okteto push $params
+echo running: okteto push $params
 okteto push $params
 
 kubectl rollout status deployment/$name --namespace "$namespace" --timeout=300s

--- a/push/entrypoint.sh
+++ b/push/entrypoint.sh
@@ -22,4 +22,6 @@ fi
 echo running: okteto push $params
 okteto push $params
 
+if [ -z "$name" ]; then
 kubectl rollout status deployment/$name --namespace "$namespace" --timeout=300s
+fi

--- a/push/entrypoint.sh
+++ b/push/entrypoint.sh
@@ -23,5 +23,7 @@ echo running: okteto push $params
 okteto push $params
 
 if [ -z "$name" ]; then
-kubectl rollout status deployment/$name --namespace "$namespace" --timeout=300s
+name=$(yq r okteto.yml name)
 fi
+
+kubectl rollout status deployment/$name --namespace "$namespace" --timeout=300s

--- a/push/entrypoint.sh
+++ b/push/entrypoint.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+set -e
+
+token=$1
+deploy=$2
+name=$3
+
+okteto login --token=$token
+params=""
+
+if [ "$deploy" == "true" ]; then
+params="--deploy"
+fi
+
+if [ ! -z "$name" ]; then
+params="${params} --name $name"
+fi
+
+echo okteto push $params
+okteto push $params

--- a/push/entrypoint.sh
+++ b/push/entrypoint.sh
@@ -1,20 +1,25 @@
 #!/bin/sh
 set -e
 
-token=$1
-deploy=$2
-name=$3
+namespace=$1
+name=$2
+deploy=$3
 
-okteto login --token=$token
 params=""
 
-if [ "$deploy" == "true" ]; then
-params="--deploy"
+if [ ! -z "$namespace" ]; then
+params="${params} --namespace $namespace"
 fi
 
 if [ ! -z "$name" ]; then
 params="${params} --name $name"
 fi
 
+if [ "$deploy" == "true" ]; then
+params="--deploy"
+fi
+
 echo okteto push $params
 okteto push $params
+
+kubectl rollout status deployment/$name --namespace "$namespace" --timeout=300s


### PR DESCRIPTION
Proposed changes:
- Have a separate action for login, that should be called first
- Remove login from all actions
- Support to specify an  okteto enterprise URL
- Add actions for push, create namespace and delete namespace

You can see an example of how this would look like here: https://github.com/rberrelleza/actions-test/blob/42ab44b5e1a4b66e0190e3888a94f869dfa29c28/.github/workflows/main.yaml